### PR TITLE
enable mod_rewrite for netmon's rest api .htaccess

### DIFF
--- a/manifests/apache_common.pp
+++ b/manifests/apache_common.pp
@@ -22,6 +22,9 @@ class gluon::apache_common {
     class { 'apache::mod::php':
     }
 
+    class { 'apache::mod::rewrite':
+    }
+
     package { [ 'php5-mysql', 'php5-gmp', 'php5-curl', 'php5-gd' ]:
         ensure  => present,
     }


### PR DESCRIPTION
I'm not at all a puppet expert but following the scheme it seems that this should enable mod_rewrite and therefore allow the netmon rest api to be used as documented through the rewrites in its .htaccess